### PR TITLE
Implement "done" toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You can read the blog [here](https://dev.to/devtony101/javascript-building-a-to-
 - **Create a task**: You can create a brand new task with a given title and description. Later that task is saved using JavaScript IndexedDB API.
 - **Show saved tasks**: Everytime the page loads it will query the indexed database to get all saved tasks and display them as panels at the bottom of the page.
 - **Edit a task**: You can edit any given task at any given moment.
+- **Toggle the "done" status of a task**: You can toggle whether a task is "done" via either a checkbox or while editing the task.
 
 ## Want to code along?
 Here are the starting and finished code templates for each part of the tutorial series.

--- a/dist/assets/css/index.css
+++ b/dist/assets/css/index.css
@@ -149,3 +149,8 @@ body {
   from {top:-300px; opacity:0}
   to {top:0; opacity:1}
 }
+
+/* Complete item */
+.message.is-done p {
+  text-decoration: line-through;
+}

--- a/dist/index.html
+++ b/dist/index.html
@@ -9,7 +9,7 @@
   <link rel="manifest" href="./assets/favicon/site.webmanifest">
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">
   <link rel="stylesheet" href="./assets/css/index.css"/>
   <title>To-Do App</title>
 </head>

--- a/dist/index.html
+++ b/dist/index.html
@@ -83,6 +83,13 @@
           </div>
         </div>
 
+        <div class="field">
+          <label class="checkbox">
+            <input type="checkbox" id="editDone">
+            Done
+          </label>
+        </div>
+
         <div class="field is-grouped">
           <div class="control">
             <button id="btnsave" type="submit" class="button is-primary">Save Changes</button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1805,11 +1805,6 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
-    "bulma": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.0.tgz",
-      "integrity": "sha512-rV75CJkubNUroAt0qCRkjznZLoaXq/ctfMXsMvKSL84UetbSyx5REl96e8GoQ04G4Tkw0XF3STECffTOQrbzOQ=="
-    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,5 @@
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0"
-  },
-  "dependencies": {
-    "bulma": "^0.9.0"
   }
 }

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -78,4 +78,20 @@ export default class Database {
       throw new Error("Parameter 'id' expected to be a number.");
     }
   }
+
+  toggleDone(id, isDone, success) {
+    if (typeof id === "number") {
+      const transaction = this.indexedDB.transaction([this.name], "readwrite");
+      const objectStore = transaction.objectStore(this.name);
+      objectStore.get(id).onsuccess = function (event) {
+        const task = event.target.result;
+        task.done = isDone;
+        const request = objectStore.put(task);
+        if (typeof success === "function") request.onsuccess = success;
+      };
+      return transaction;
+    } else {
+      throw new Error("Parameter 'id' expected to be a number.");
+    }
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -52,17 +52,24 @@ document.addEventListener("DOMContentLoaded", () => {
       const cursor = event.target.result;
       if (cursor) {
         const {key, title, description} = cursor.value;
+
+        // Message container
         const message = document.createElement("article");
         message.classList.add("message", "is-primary");
         message.setAttribute("data-id", key);
-        message.innerHTML = `
-          <div class="message-header">
-            <p>${title}</p>
-          </div>
-          <div class="message-body">
-            <p>${description}</p>
-          </div>
-        `;
+        tasksContainer.appendChild(message);
+
+        // Message header
+        const messageHeader = document.createElement("div");
+        messageHeader.classList.add("message-header");
+        messageHeader.innerHTML = `<p>${title}</p>`;
+        message.appendChild(messageHeader);
+
+        // Message body
+        const messageBody = document.createElement("div");
+        messageBody.classList.add("message-body");
+        messageBody.innerHTML = `<p>${description}</p>`;
+        message.appendChild(messageBody);
 
         // Creating the delete button element
         const deleteButton = document.createElement("button");
@@ -71,22 +78,22 @@ document.addEventListener("DOMContentLoaded", () => {
         deleteButton.onclick = removeTask;
 
         // Adding it to the div message header
-        message.firstChild.nextSibling.appendChild(deleteButton);
-        tasksContainer.appendChild(message);
+        messageHeader.appendChild(deleteButton);
+
+        // Add a container for controls
+        const controlsContainer = document.createElement("div");
+        controlsContainer.classList.add("mt-4", "is-flex", "is-align-items-baseline");
+        messageBody.appendChild(controlsContainer);
 
         // Creating the edit task button element
         const editButton = document.createElement("button");
         editButton.classList.add("button");
         editButton.innerHTML = "Edit";
         editButton.setAttribute("aria-label","edit");
-        editButton.style.marginTop = "20px";
         editButton.onclick = editTask;
 
-        // Adding it to the div message body
-        console.log(message.children[1]);
-        // console.log(message.children[-1]);
-        message.children[1].appendChild(editButton);
-        tasksContainer.appendChild(message);
+        // Adding it to the controls container
+        controlsContainer.appendChild(editButton);
 
         cursor.continue();
 
@@ -101,8 +108,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function removeTask(event) {
-    const header = event.target.parentElement;
-    const task = header.parentElement;
+    const task = event.currentTarget.closest(".message");
     const id = Number(task.getAttribute("data-id"));
     database.delete(id, () => {
       // Step 1
@@ -122,8 +128,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // filling up the modal with values of the respective to-do task
   function editTask(event){
-    const header = event.target.parentElement;
-    const task = header.parentElement;
+    const task = event.currentTarget.closest(".message");
     const id = Number(task.getAttribute("data-id"));
     const val = database.getField(id);
     val.onsuccess = () => {


### PR DESCRIPTION
This addresses #3.

- Remove Bulma from NPM dependencies
  Bulma is pulled in via a CDN, so there's no need to install it via NPM.
- Update Bulma to 0.9.1
  This is needed for the various flexbox helpers.
- Restructure task HTML slightly
  - Build it a little more programmatically, so that the message header and body elements are referenced
  - Put the 'edit' button in a container element which is styled as a flexbox
  - Use bulma's spacing helpers rather than applying via a style attribute
  - Select the message an event references via Element.closest rather than (brittle) Element.parentNode calls
- Allow items to be marked as 'done'
  - Add a boolean 'done' field to the task type
  - New tasks are created with 'done' set to false
  - The edit task form has a 'done' checkbox
  - Task cards have a 'done' checkbox next to the 'edit' button which allows the 'done' status to be toggled with a single click
  - Tasks which are marked as done have their title and description decorated with strikethrough