### PR TITLE
Add initial configuration for webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,6 @@
     "build": "webpack --mode production",
     "start": "webpack-dev-server --mode development"
   },
-  "devServer": {
-    "publicPath": "/",
-    "contentBase": "./src",
-    "hot": true
-  },
   "keywords": [
     "example",
     "tutorial",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "build": "webpack --mode production",
     "start": "webpack-dev-server --mode development"
   },
+  "devServer": {
+    "publicPath": "/",
+    "contentBase": "./src",
+    "hot": true
+  },
   "keywords": [
     "example",
     "tutorial",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,4 +12,9 @@ module.exports = {
       { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" }
     ],
   },
+  devServer: {
+    publicPath: "/",
+    contentBase: "./dist",
+    hot: true
+  },
 };


### PR DESCRIPTION
# Description

This pull request adds an initial configuration in the `package.json` that avoids the `webpack-dev-server` to display the directory list in the `localhost:8080` (what happened to me) and makes it display the actual content from the index page when executed the `npm run start` command is executed.

## Type of change

This is a:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (fixes or update of an existing feature)

## Checklist:

By making this contribution I ensure that:

- [x] I have read the [contribution guide](https://github.com/DevTony101/js-todo-app-indexed_db/blob/master/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [README file](https://github.com/DevTony101/js-todo-app-indexed_db#features) (if this PR introduces a new feature)
- [x] My changes generate no new warnings
